### PR TITLE
ignore temp files after yarn install/generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vercel
+/.nuxt
+/.output
+/node_modules
+/dist


### PR DESCRIPTION
Hello, I noticed that the temporary files created during `yarn install/dev/generate` are not currently ignored by the `.gitignore` file. I have updated the `.gitignore` to include these files